### PR TITLE
Create 8 static HTML pages (fixes #1)

### DIFF
--- a/1.html
+++ b/1.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page 1</title>
+</head>
+<body>
+    <h1>1</h1>
+</body>
+</html>

--- a/2.html
+++ b/2.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page 2</title>
+</head>
+<body>
+    <h1>2</h1>
+</body>
+</html>

--- a/3.html
+++ b/3.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page 3</title>
+</head>
+<body>
+    <h1>3</h1>
+</body>
+</html>

--- a/4.html
+++ b/4.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page 4</title>
+</head>
+<body>
+    <h1>4</h1>
+</body>
+</html>

--- a/5.html
+++ b/5.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page 5</title>
+</head>
+<body>
+    <h1>5</h1>
+</body>
+</html>

--- a/6.html
+++ b/6.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page 6</title>
+</head>
+<body>
+    <h1>6</h1>
+</body>
+</html>

--- a/7.html
+++ b/7.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page 7</title>
+</head>
+<body>
+    <h1>7</h1>
+</body>
+</html>

--- a/8.html
+++ b/8.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page 8</title>
+</head>
+<body>
+    <h1>8</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Implements 8 static HTML pages for GitHub Pages deployment as requested in #1

## Problem
Issue #1 requested the creation of 8 static HTML pages (1.html through 8.html) that will be deployed via GitHub Pages. Each page should display its corresponding number.

## Solution
Created 8 HTML files with proper HTML5 structure, each displaying its corresponding number (1-8) as the main content.

## Changes
- Created 1.html with content "1"
- Created 2.html with content "2"
- Created 3.html with content "3"
- Created 4.html with content "4"
- Created 5.html with content "5"
- Created 6.html with content "6"
- Created 7.html with content "7"
- Created 8.html with content "8"
- All files include proper HTML5 structure with DOCTYPE, meta tags, and semantic markup

## Testing
- [x] All 8 HTML files created successfully
- [x] Each file contains valid HTML5 markup
- [x] Each page displays its corresponding number
- Ready for GitHub Pages deployment

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)