### PR TITLE
Import Copilot auto-review workflow (fixes #8)

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,72 @@
+name: Auto Copilot Review
+
+# Trigger on new PRs and updates
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-copilot-review:
+    name: Auto-trigger Copilot Review
+    runs-on: ubuntu-latest
+
+    # Skip for dependabot and draft PRs, but allow workflow_dispatch
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false)
+
+    steps:
+    - name: Check gh CLI availability
+      run: command -v gh || (echo "gh CLI not found" && exit 1)
+
+    - name: Request Copilot code review
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+      run: |
+        echo "🤖 Requesting Copilot code review for PR #${PR_NUMBER}"
+
+        # Request review from Copilot using GitHub API
+        # The reviewer slug for Copilot is "copilot"
+        gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${{ github.repository }}/pulls/${PR_NUMBER}/requested_reviewers \
+          -f "reviewers[]=copilot" \
+        && echo "✅ Successfully requested Copilot review" \
+        || echo "⚠️ Failed to request Copilot review - it may already be reviewing or automatic reviews may be enabled in repository settings"
+
+    - name: Add label
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+      run: |
+        # Create label if it doesn't exist
+        gh label create "copilot-review" \
+          --repo ${{ github.repository }} \
+          --description "Copilot code review requested" \
+          --color "0075ca" 2>/dev/null || true
+
+        # Add label to PR
+        gh pr edit ${PR_NUMBER} --repo ${{ github.repository }} --add-label "copilot-review" || true
+
+    - name: Summary
+      run: |
+        echo "### ✅ Copilot Review Requested" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- PR #${{ github.event.pull_request.number || inputs.pr_number }} - Copilot review requested via API" >> $GITHUB_STEP_SUMMARY
+        echo "- Label added: \`copilot-review\`" >> $GITHUB_STEP_SUMMARY
+        echo "- Copilot will appear in the Reviewers section and provide feedback" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Note**: If automatic reviews are enabled in repository settings, Copilot may already be reviewing." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Imports the automatic Copilot code review workflow from the CAPZTests repository as requested in #8.

## Problem
The repository needs automated Copilot code review functionality to automatically request Copilot reviews on pull requests.

## Solution
Imported the `copilot-review.yml` workflow from the CAPZTests repository. This workflow automatically requests Copilot as a reviewer when PRs are opened, updated, or reopened.

## Changes
- **`.github/workflows/copilot-review.yml`**: New GitHub Actions workflow file
  - Triggers on PR events: opened, synchronize, reopened
  - Supports manual triggering via `workflow_dispatch` with PR number input
  - Uses GitHub CLI to request Copilot as a reviewer via GitHub API
  - Automatically creates and adds "copilot-review" label to PRs
  - Skips dependabot PRs and draft PRs
  - Provides workflow summary in GitHub Actions UI

## Features
- **Automatic Review Requests**: Copilot is automatically requested as a reviewer on new PRs
- **Label Management**: Creates "copilot-review" label if it doesn't exist and applies it to PRs
- **Manual Trigger**: Can be manually triggered for specific PR numbers
- **Smart Filtering**: Skips dependabot and draft PRs to reduce noise
- **Error Handling**: Gracefully handles cases where Copilot is already reviewing

## Testing
- [x] Workflow file created with valid YAML syntax
- [x] Imported from proven workflow at RadekCap/CAPZTests
- [ ] Workflow will be tested when this PR is merged (should trigger automatically on future PRs)

## Usage
Once merged, this workflow will:
1. Automatically run on every new PR and PR update
2. Request Copilot as a reviewer via GitHub API
3. Add the "copilot-review" label to the PR
4. Display a summary in the Actions tab

You can also manually trigger it:
1. Go to Actions → Auto Copilot Review
2. Click "Run workflow"
3. Enter the PR number to review

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)