### PR TITLE
Add navigation between pages (fixes #15)

### DIFF
--- a/1.html
+++ b/1.html
@@ -40,6 +40,24 @@
             font-size: 60px;
             margin: 20px 0;
         }
+        .navigation {
+            margin-top: 30px;
+        }
+        .nav-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            text-decoration: none;
+            border-radius: 25px;
+            font-size: 18px;
+            font-weight: bold;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .nav-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+        }
     </style>
     <script>
         window.addEventListener('load', function() {
@@ -58,6 +76,9 @@
         <div class="emoji">🌊</div>
         <div class="riddle">
             Kde víří pěna jako v moři a oblečení se tam točí dokola? Které místo zabručí pokaždé, když začne pracovat?
+        </div>
+        <div class="navigation">
+            <a href="2.html" class="nav-button">Další →</a>
         </div>
     </div>
 </body>

--- a/2.html
+++ b/2.html
@@ -40,6 +40,24 @@
             font-size: 60px;
             margin: 20px 0;
         }
+        .navigation {
+            margin-top: 30px;
+        }
+        .nav-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+            color: white;
+            text-decoration: none;
+            border-radius: 25px;
+            font-size: 18px;
+            font-weight: bold;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .nav-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+        }
     </style>
     <script>
         window.addEventListener('load', function() {
@@ -58,6 +76,9 @@
         <div class="emoji">🍪</div>
         <div class="riddle">
             Tichý kout, kde sklenice a sáčky šeptají svá tajemství. Když hledáš cukr, mouku nebo skrytou sušenku, otevřeš právě mě.
+        </div>
+        <div class="navigation">
+            <a href="3.html" class="nav-button">Další →</a>
         </div>
     </div>
 </body>

--- a/3.html
+++ b/3.html
@@ -40,6 +40,24 @@
             font-size: 60px;
             margin: 20px 0;
         }
+        .navigation {
+            margin-top: 30px;
+        }
+        .nav-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+            color: white;
+            text-decoration: none;
+            border-radius: 25px;
+            font-size: 18px;
+            font-weight: bold;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .nav-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+        }
     </style>
     <script>
         window.addEventListener('load', function() {
@@ -58,6 +76,9 @@
         <div class="emoji">📻</div>
         <div class="riddle">
             Vlny uvnitř tiše tančí, jídlo jim hraje na notu bez ohně. Kdo cvakne dvířka a za chvíli pípne — kde to hučí a ohřívá se talíř?
+        </div>
+        <div class="navigation">
+            <a href="4.html" class="nav-button">Další →</a>
         </div>
     </div>
 </body>

--- a/4.html
+++ b/4.html
@@ -40,6 +40,24 @@
             font-size: 60px;
             margin: 20px 0;
         }
+        .navigation {
+            margin-top: 30px;
+        }
+        .nav-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
+            color: white;
+            text-decoration: none;
+            border-radius: 25px;
+            font-size: 18px;
+            font-weight: bold;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .nav-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+        }
     </style>
     <script>
         window.addEventListener('load', function() {
@@ -58,6 +76,9 @@
         <div class="emoji">🍞</div>
         <div class="riddle">
             Vnitřek mám žhavý jako letní slunce, dovnitř vložíš těsto a ven vyjde zlatý zázrak. Když se zapnu, voní to po chlebu a koláčích — kde se to děje?
+        </div>
+        <div class="navigation">
+            <a href="5.html" class="nav-button">Další →</a>
         </div>
     </div>
 </body>

--- a/5.html
+++ b/5.html
@@ -40,6 +40,24 @@
             font-size: 60px;
             margin: 20px 0;
         }
+        .navigation {
+            margin-top: 30px;
+        }
+        .nav-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: linear-gradient(135deg, #30cfd0 0%, #330867 100%);
+            color: white;
+            text-decoration: none;
+            border-radius: 25px;
+            font-size: 18px;
+            font-weight: bold;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .nav-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+        }
     </style>
     <script>
         window.addEventListener('load', function() {
@@ -58,6 +76,9 @@
         <div class="emoji">🧹</div>
         <div class="clue">
             Špinavé hadříky, špinavá hadříky, je jich tam hromada.
+        </div>
+        <div class="navigation">
+            <a href="6.html" class="nav-button">Další →</a>
         </div>
     </div>
 </body>

--- a/6.html
+++ b/6.html
@@ -48,6 +48,24 @@
             font-style: italic;
             margin-top: 20px;
         }
+        .navigation {
+            margin-top: 30px;
+        }
+        .nav-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
+            color: #333;
+            text-decoration: none;
+            border-radius: 25px;
+            font-size: 18px;
+            font-weight: bold;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .nav-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+        }
     </style>
     <script>
         window.addEventListener('load', function() {
@@ -68,6 +86,9 @@
             ..- | --- | -. | .-. | .- | -.- | ... | .. | - | .- | --..
         </div>
         <div class="hint">Morseova abeceda</div>
+        <div class="navigation">
+            <a href="7.html" class="nav-button">Další →</a>
+        </div>
     </div>
 </body>
 </html>

--- a/7.html
+++ b/7.html
@@ -40,6 +40,24 @@
             font-size: 60px;
             margin: 20px 0;
         }
+        .navigation {
+            margin-top: 30px;
+        }
+        .nav-button {
+            display: inline-block;
+            padding: 12px 30px;
+            background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
+            color: white;
+            text-decoration: none;
+            border-radius: 25px;
+            font-size: 18px;
+            font-weight: bold;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .nav-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+        }
     </style>
     <script>
         window.addEventListener('load', function() {
@@ -58,6 +76,9 @@
         <div class="emoji">🐱</div>
         <div class="riddle">
             V misce šustí naděje a kočičí nos se k němu sklání. Dává sílu skákat, mňoukat i přitulit se k nohám — kde to je?
+        </div>
+        <div class="navigation">
+            <a href="8.html" class="nav-button">Další →</a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
Implemented sequential navigation across all HTML pages as requested in issue #15.

## Problem
The pages lacked navigation between them, making it difficult for users to progress through the riddles and clues sequentially.

## Solution
Added a "Další →" (Next) navigation button at the bottom of each page (1-7) that links to the subsequent page. Each button is styled to match the gradient theme of its respective page.

## Changes
- Added navigation CSS styles to pages 1.html through 7.html
- Added "Další →" button linking to the next page in sequence
- Each button uses the page's gradient theme for visual consistency
- Implemented hover effects with smooth transitions

## Testing
- [x] Navigation flow verified through all pages (1→2→3→4→5→6→7→8)
- [x] Visual consistency confirmed across all pages
- [x] Hover effects working properly

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)