### PR TITLE
Remove password protection from all pages (fixes #16)

### DIFF
--- a/1.html
+++ b/1.html
@@ -59,16 +59,6 @@
             box-shadow: 0 5px 15px rgba(0,0,0,0.3);
         }
     </style>
-    <script>
-        window.addEventListener('load', function() {
-            var password = prompt('Napiš tajné heslo');
-            if (password !== 'test') {
-                document.body.innerHTML = '';
-                alert('Špatné heslo!');
-                window.location.href = 'about:blank';
-            }
-        });
-    </script>
 </head>
 <body>
     <div class="container">

--- a/2.html
+++ b/2.html
@@ -59,16 +59,6 @@
             box-shadow: 0 5px 15px rgba(0,0,0,0.3);
         }
     </style>
-    <script>
-        window.addEventListener('load', function() {
-            var password = prompt('Napiš tajné heslo');
-            if (password !== 'test') {
-                document.body.innerHTML = '';
-                alert('Špatné heslo!');
-                window.location.href = 'about:blank';
-            }
-        });
-    </script>
 </head>
 <body>
     <div class="container">

--- a/3.html
+++ b/3.html
@@ -59,16 +59,6 @@
             box-shadow: 0 5px 15px rgba(0,0,0,0.3);
         }
     </style>
-    <script>
-        window.addEventListener('load', function() {
-            var password = prompt('Napiš tajné heslo');
-            if (password !== 'test') {
-                document.body.innerHTML = '';
-                alert('Špatné heslo!');
-                window.location.href = 'about:blank';
-            }
-        });
-    </script>
 </head>
 <body>
     <div class="container">

--- a/4.html
+++ b/4.html
@@ -59,16 +59,6 @@
             box-shadow: 0 5px 15px rgba(0,0,0,0.3);
         }
     </style>
-    <script>
-        window.addEventListener('load', function() {
-            var password = prompt('Napiš tajné heslo');
-            if (password !== 'test') {
-                document.body.innerHTML = '';
-                alert('Špatné heslo!');
-                window.location.href = 'about:blank';
-            }
-        });
-    </script>
 </head>
 <body>
     <div class="container">

--- a/5.html
+++ b/5.html
@@ -59,16 +59,6 @@
             box-shadow: 0 5px 15px rgba(0,0,0,0.3);
         }
     </style>
-    <script>
-        window.addEventListener('load', function() {
-            var password = prompt('Napiš tajné heslo');
-            if (password !== 'test') {
-                document.body.innerHTML = '';
-                alert('Špatné heslo!');
-                window.location.href = 'about:blank';
-            }
-        });
-    </script>
 </head>
 <body>
     <div class="container">

--- a/6.html
+++ b/6.html
@@ -67,16 +67,6 @@
             box-shadow: 0 5px 15px rgba(0,0,0,0.3);
         }
     </style>
-    <script>
-        window.addEventListener('load', function() {
-            var password = prompt('Napiš tajné heslo');
-            if (password !== 'test') {
-                document.body.innerHTML = '';
-                alert('Špatné heslo!');
-                window.location.href = 'about:blank';
-            }
-        });
-    </script>
 </head>
 <body>
     <div class="container">

--- a/7.html
+++ b/7.html
@@ -59,16 +59,6 @@
             box-shadow: 0 5px 15px rgba(0,0,0,0.3);
         }
     </style>
-    <script>
-        window.addEventListener('load', function() {
-            var password = prompt('Napiš tajné heslo');
-            if (password !== 'test') {
-                document.body.innerHTML = '';
-                alert('Špatné heslo!');
-                window.location.href = 'about:blank';
-            }
-        });
-    </script>
 </head>
 <body>
     <div class="container">

--- a/8.html
+++ b/8.html
@@ -58,16 +58,6 @@
             margin-top: 20px;
         }
     </style>
-    <script>
-        window.addEventListener('load', function() {
-            var password = prompt('Napiš tajné heslo');
-            if (password !== 'test') {
-                document.body.innerHTML = '';
-                alert('Špatné heslo!');
-                window.location.href = 'about:blank';
-            }
-        });
-    </script>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
## Summary
Removed JavaScript password prompts from all HTML pages as requested in issue #16.

## Problem
All pages (1.html through 8.html) had password protection that required users to enter "test" to access the content. This added unnecessary friction to the user experience.

## Solution
Removed the password protection `<script>` blocks from all 8 HTML pages, allowing users to access the content directly without authentication.

## Changes
- Removed password prompt script from 1.html
- Removed password prompt script from 2.html
- Removed password prompt script from 3.html
- Removed password prompt script from 4.html
- Removed password prompt script from 5.html
- Removed password prompt script from 6.html
- Removed password prompt script from 7.html
- Removed password prompt script from 8.html

## Testing
- [x] All pages now load without password prompts
- [x] Navigation between pages still works correctly
- [x] Page content and styling remain unchanged

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)